### PR TITLE
Update composer.json for the first release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "google/cloud-grpc",
+    "name": "google/grpc-gcp",
     "description": "gRPC gcp library for channel management",
     "license": "Apache-2.0",
     "version": "0.0.1",
@@ -9,14 +9,15 @@
     "require": {
         "php": ">=5.5.0",
         "google/protobuf": "^v3.3.0",
-        "grpc/grpc": "dev-master",
+        "grpc/grpc": "^v1.13.0",
+        "google/auth": "^1.3",
         "psr/cache": "^1.0.1"
     },
     "require-dev": {
     },
     "autoload": {
         "psr-4": {
-            "Grpc\\Gcp": "src/",
+            "Grpc\\Gcp\\": "src/",
             "": ["src/generated/"]
         }
     }


### PR DESCRIPTION
Since google cloud php repo has updated the gRPC dependency to v1.13.0, we can release the grpc-gcp library to substitute the test release to the official release:
https://github.com/GoogleCloudPlatform/google-cloud-php/pull/1146

The library name will be `google/grpc-gcp` and downloaded by `$composer install google/grpc-gcp`.