### PR TITLE
Fix PHP 7.3 switch warning

### DIFF
--- a/src/GcpExtensionChannel.php
+++ b/src/GcpExtensionChannel.php
@@ -199,11 +199,10 @@ class GcpExtensionChannel
         $shutdown = 0;
         foreach ($this->channel_refs as $channel_ref) {
             $state = $channel_ref->getRealChannel($this->credentials)->getConnectivityState($try_to_connect);
-            print_r($state);
             switch ($state) {
                 case \Grpc\CHANNEL_READY:
                     $ready += 1;
-                    break;
+                    break 2;
                 case \Grpc\CHANNEL_FATAL_FAILURE:
                     $shutdown += 1;
                     break;

--- a/src/GcpExtensionChannel.php
+++ b/src/GcpExtensionChannel.php
@@ -206,16 +206,16 @@ class GcpExtensionChannel
                     break;
                 case \Grpc\CHANNEL_FATAL_FAILURE:
                     $shutdown += 1;
-                    continue;
+                    break;
                 case \Grpc\CHANNEL_CONNECTING:
                     $connecting += 1;
-                    continue;
+                    break;
                 case \Grpc\CHANNEL_TRANSIENT_FAILURE:
                     $transient_failure += 1;
-                    continue;
+                    break;
                 case \Grpc\CHANNEL_IDLE:
                     $idle += 1;
-                    continue;
+                    break;
             }
         }
         if ($ready > 0) {


### PR DESCRIPTION
Beginning in PHP 7.3, PHP raises a Warning when using `continue` within a `switch` control structure. ([see relevant RFC](https://wiki.php.net/rfc/continue_on_switch_deprecation))

PHP has always treated `continue` as equivalent to `break`, which is different from some other languages (the only thing that's changed is now the language tells you about it).

Error message:

```
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"
```

Since there's nothing after the switch in the loop, `break` is functionally equivalent to the (perhaps) intended behavior of `continue 2`.

Can you also advise on whether the `print_r` immediately above the switch is intended?