### PR TITLE
chore: remove "version" from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "google/grpc-gcp",
     "description": "gRPC GCP library for channel management",
     "license": "Apache-2.0",
-    "version": "0.1.5",
     "require": {
         "php": ">=5.5.0",
         "google/protobuf": "^v3.3.0",


### PR DESCRIPTION
See https://getcomposer.org/doc/04-schema.md#description

> Optional if the package repository can infer the version from somewhere, such as the VCS tag name in the VCS repository. In that case it is also recommended to omit it.

That is the case with github, the tag is inferred from the git tag, so it should be omitted.