### PR TITLE
fix: Using of dynamic property is deprecated in PHP 8.2

### DIFF
--- a/cloudprober/grpc_gpc_prober/stackdriver_util.php
+++ b/cloudprober/grpc_gpc_prober/stackdriver_util.php
@@ -7,6 +7,7 @@ use Google\Cloud\ErrorReporting\V1beta1\ErrorContext;
 use Google\Cloud\ErrorReporting\V1beta1\ReportedErrorEvent;
 use Google\Cloud\ErrorReporting\V1beta1\SourceLocation;
 
+#[\AllowDynamicProperties]
 class StackdriverUtil{
 	function __construct($api){
 		$this->api = $api;

--- a/cloudprober/grpc_gpc_prober/stackdriver_util.php
+++ b/cloudprober/grpc_gpc_prober/stackdriver_util.php
@@ -7,8 +7,12 @@ use Google\Cloud\ErrorReporting\V1beta1\ErrorContext;
 use Google\Cloud\ErrorReporting\V1beta1\ReportedErrorEvent;
 use Google\Cloud\ErrorReporting\V1beta1\SourceLocation;
 
-#[\AllowDynamicProperties]
 class StackdriverUtil{
+	protected $api;
+	protected $metrics;
+	protected $success;
+	protected $err_client;
+
 	function __construct($api){
 		$this->api = $api;
 		$this->metrics = [];

--- a/src/GcpBaseCall.php
+++ b/src/GcpBaseCall.php
@@ -38,6 +38,7 @@ abstract class GcpBaseCall
     protected $argument;
     protected $metadata;
     protected $options;
+    protected $deserialize;
 
     // In GCP extension, it is when a RPC calls "start", we pick a channel.
     // Thus we need to save the $me


### PR DESCRIPTION
fixes #50 

I found  `stackdriver_util.php` also has dynamic properties by IntelliJ inspect code command.
I think it'll be broken in PHP8.2, so I add [error suppress annotation](https://www.php.net/manual/en/migration82.deprecated.php) to it.
But I don't know how to test `stackdriver_util.php` .
So I’m not sure `stackdriver_util.php` fixed, sorry.

I confirm `src/GcpBaseCall.php` fixed.