### PR TITLE
Fix PHP deprecations and warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ "8.0", "8.1", "8.2", "8.3" ]
+        php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
     name: "PHP ${{ matrix.php }} Unit Test"
     steps:
       - uses: actions/checkout@v2

--- a/src/Config.php
+++ b/src/Config.php
@@ -37,7 +37,7 @@ class Config
      *                                            cross requests within a single worker process.
      * @throws \RuntimeException When a failure occurs while attempting to attach to shared memory.
      */
-    public function __construct($target, $conf = null, CacheItemPoolInterface $cacheItemPool = null)
+    public function __construct($target, $conf = null, ?CacheItemPoolInterface $cacheItemPool = null)
     {
         if ($conf == null) {
             // If there is no configure file, use the default gRPC channel.

--- a/tests/grpc-gcp/grpc_unit_test/ChannelTest.php
+++ b/tests/grpc-gcp/grpc_unit_test/ChannelTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 
 class ChannelTest extends TestCase
 {
+    private Grpc\Gcp\GcpExtensionChannel $channel;
+    private Grpc\Gcp\GcpExtensionChannel $channel1;
+    private Grpc\Gcp\GcpExtensionChannel $channel2;
+    private Grpc\Gcp\GcpExtensionChannel $channel3;
+
     public function tearDown(): void
     {
         if (!empty($this->channel)) {

--- a/tests/grpc-gcp/grpc_unit_test/ChannelTest.php
+++ b/tests/grpc-gcp/grpc_unit_test/ChannelTest.php
@@ -37,7 +37,6 @@ class ChannelTest extends TestCase
     {
         $this->channel = new Grpc\Gcp\GcpExtensionChannel('localhost:50000',
           ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
-        print_r(get_class($this->channel));
         $this->assertSame('Grpc\Gcp\GcpExtensionChannel', get_class($this->channel));
     }
 
@@ -90,7 +89,6 @@ class ChannelTest extends TestCase
         // we act as if 'CONNECTING'(=1) was the last state
         // we saw, so the default state of 'IDLE' should be delivered instantly
         $state = $this->channel->watchConnectivityState(3, $deadline);
-        print_r($state);
         $this->assertTrue($state);
         unset($now);
         unset($deadline);

--- a/tests/grpc-gcp/grpc_unit_test/ChannelTest.php
+++ b/tests/grpc-gcp/grpc_unit_test/ChannelTest.php
@@ -18,7 +18,6 @@
  */
 
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
 
 class ChannelTest extends TestCase
 {


### PR DESCRIPTION
Fixes #57 

* Fix: `use` statement with no effect emits warning:
  * ```PHP Warning:  The use statement with non-compound name 'InvalidArgumentException' has no effect in tests/grpc-gcp/grpc_unit_test/ChannelTest.php on line 21```
* Fix: Creation of dynamic properties emits deprecation warnings:
  *  ```PHP Deprecated:  Creation of dynamic property ChannelTest::$channel1 is deprecated in tests/grpc-gcp/grpc_unit_test/ChannelTest.php on line 179```
* Fix: Implicitly nullable parameter types are deprecated in PHP 8.4
  * https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
  * `?Type` syntax was introduced in PHP 7.1, and the library supports `>8.0`, so there is no backward compatibility issue
    * https://wiki.php.net/rfc/nullable_types