### PR TITLE
Update .gitattributes to exclude dev files from composer dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@
 /cloud-apis export-ignore
 /cloudprober/bins export-ignore
 phpunit.xml.dist export-ignore
+/doc/ export-ignore
+/.github/ export-ignore
+/.php_cs.dist export-ignore


### PR DESCRIPTION
This avoids shipping dev/tooling files in the composer dist that aren't needed at runtime.

Last `.gitattributes` update was b0cf139 (2026-03-13, #59). The files below have been added or modified since, and are still included in the composer dist:
- `/doc/ export-ignore` — last touched in 2d903e2 2018-07-09 (initial)
- `/.github/ export-ignore` — last touched in 1049c0c 2026-03-12 (#58)
- `/.php_cs.dist export-ignore` — last touched in 2d903e2 2018-07-09 (initial)

Background reading: https://blog.madewithlove.be/post/gitattributes/